### PR TITLE
Add region list exports and directories

### DIFF
--- a/Boxplot
+++ b/Boxplot
@@ -28,7 +28,8 @@ execution_metadata <- list(
   data_year = "2023",
   style = "WTO/ADB/GAI Editorial Standard - Faceted Panel Boxplots Fixed",
   clean_data_source_path = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex",
-  export_path = "/Volumes/VALEN/Africa:LAC/Harmonization/GVC AFRICA/faceted_panel_boxplots_101_countries_fixed"
+  export_root = "/Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH",
+  export_path = file.path(export_root, "faceted_panel_boxplots_101_countries_fixed")
 )
 
 # Create export directory
@@ -617,7 +618,8 @@ execution_metadata <- list(
   data_year = "2023",
   style = "WTO/ADB/GAI Editorial Standard - Complete Pipeline with Top Performer Highlighting",
   clean_data_source_path = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex",
-  export_path = "/Volumes/VALEN/Africa:LAC/Harmonization/GVC AFRICA"
+  export_root = "/Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH",
+  export_path = file.path(export_root)
 )
 
 # Create export directories
@@ -1681,7 +1683,8 @@ execution_metadata <- list(
   version = "Statistical_Description_v2.1_GVC_AFRICA_EXPORT",
   analysis_type = "Comprehensive Statistical Summary with Four-Pillar Rankings",
   data_source = "Clean GAI Editorial Indicators",
-  export_path = "/Volumes/VALEN/Africa:LAC/Harmonization/GVC AFRICA"
+  export_root = "/Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH",
+  export_path = export_root
 )
 
 message("Statistical Description Analysis with Comprehensive Rankings Started")

--- a/GVC_AFRICA_Readiness.R
+++ b/GVC_AFRICA_Readiness.R
@@ -126,6 +126,8 @@ cat("- User:", analysis_metadata$user_login, "\n\n")
 
 # Project structure setup with validation
 project_root <- "/Volumes/VALEN/Africa:LAC/AFRICA"
+# Unified export directory for all outputs
+export_root <- "/Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH"
 
 # Validate project root exists
 if (!dir.exists(project_root)) {
@@ -139,13 +141,13 @@ cat("✓ Project root validated:", project_root, "\n")
 params <- list(
   # Core directories
   data_path      = file.path(project_root, "Data"),
-  export_root    = file.path(project_root, "export"),
-  clean_dir      = file.path(project_root, "export", "clean"),
-  visual_dir     = file.path(project_root, "export", "png_pdf"),
-  excel_dir      = file.path(project_root, "export", "excel_outputs"),
-  csv_dir        = file.path(project_root, "export", "csv_outputs"),
-  logs_dir       = file.path(project_root, "export", "logs"),
-  archive_dir    = file.path(project_root, "export", "archives"),
+  export_root    = export_root,
+  clean_dir      = file.path(export_root, "clean"),
+  visual_dir     = file.path(export_root, "png_pdf"),
+  excel_dir      = file.path(export_root, "excel_outputs"),
+  csv_dir        = file.path(export_root, "csv_outputs"),
+  logs_dir       = file.path(export_root, "logs"),
+  archive_dir    = file.path(export_root, "archives"),
   
   # Analysis parameters with years for each indicator
   indicator_years = list(

--- a/Jun 6_working
+++ b/Jun 6_working
@@ -119,7 +119,8 @@ execution_metadata <- list(
   data_year = "2023",
   style = "WTO/ADB/GAI Editorial Standard - Complete Master Pipeline with Comprehensive Rankings",
   clean_data_source_path = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex",
-  export_path = "/Volumes/VALEN/Africa:LAC/Harmonization/GVC AFRICA"
+  export_root = "/Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH",
+  export_path = export_root
 )
 
 # Create export directories
@@ -2116,7 +2117,7 @@ message("\n", paste(rep("=", 80), collapse=""))
 # PILLARS: Technology | Trade & Investment | Sustainability | Institutional
 #
 # EXPORT CONFIGURATION:
-# Base Path: /Volumes/VALEN/Africa:LAC/Harmonization/GVC AFRICA/advance
+# Base Path: /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH/advance
 # Data Source: /Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex
 # Target File: Core_Pillars_Annex_138_Final.csv
 #

--- a/OK
+++ b/OK
@@ -5,7 +5,7 @@
 # Current Date and Time (UTC - YYYY-MM-DD HH:MM:SS formatted): 2025-06-07 00:15:32
 # Current User's Login: Canomoncada
 # Status: ELITE PUBLICATION-READY VERSION WITH GVC EDITORIAL STANDARDS
-# Export Directory: /Volumes/VALEN/Africa:LAC/Harmonization/Ready
+# Export Directory: /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH
 # =====================================================================================
 
 # Load Required Libraries
@@ -32,13 +32,16 @@ message("Data loading and analysis starting for user: Canomoncada at 2025-06-07 
 current_timestamp <- "2025-06-07 00:15:32"
 current_user <- "Canomoncada"
 
+# Unified export directory used across all modules
+export_root <- "/Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH"
+
 # GVC Editorial Standard Paths
 gvc_config <- list(
   # Main export directory per editorial standards
-  main_export_path = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready",
-  figures_path = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready/figures",
-  ranking_tables_path = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready/ranking_tables",
-  country_list_path = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready/Country_Lists_Complete_Pipeline.csv",
+  main_export_path = export_root,
+  figures_path = file.path(export_root, "figures"),
+  ranking_tables_path = file.path(export_root, "ranking_tables"),
+  country_list_path = file.path(export_root, "Country_Lists_Complete_Pipeline.csv"),
   # Source data path per editorial standards
   source_data_path = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex/Core_Pillars_Annex_138_Final.csv"
 )
@@ -50,7 +53,8 @@ create_gvc_directories <- function() {
   dirs_to_create <- c(
     gvc_config$main_export_path,
     gvc_config$figures_path,
-    gvc_config$ranking_tables_path
+    gvc_config$ranking_tables_path,
+    file.path(export_root, "region_lists")
   )
   
   for (dir_path in dirs_to_create) {
@@ -61,9 +65,27 @@ create_gvc_directories <- function() {
       cat("✓ Exists:", dir_path, "\n")
     }
   }
+
+  regions <- c("AFRICA", "LAC", "OECD", "ASEAN", "CHINA")
+  for (r in regions) {
+    sub_dir <- file.path(gvc_config$figures_path, r)
+    if (!dir.exists(sub_dir)) {
+      dir.create(sub_dir, recursive = TRUE)
+    }
+  }
 }
 
 create_gvc_directories()
+
+# Export region country lists
+export_region_lists <- function(region_map) {
+  list_dir <- file.path(export_root, "region_lists")
+  for (r in names(region_map)) {
+    file <- file.path(list_dir, paste0(r, "_countries.csv"))
+    write.csv(data.frame(Country = region_map[[r]]), file, row.names = FALSE)
+  }
+  cat("✓ Region lists exported to", list_dir, "\n")
+}
 
 # GVC Editorial Color Standards (EXACT SPECIFICATION)
 gvc_colors <- list(
@@ -141,6 +163,7 @@ load_gvc_data <- function() {
   if (file.exists(gvc_config$source_data_path)) {
     data <- read_csv(gvc_config$source_data_path)
     cat("✓ Source data loaded:", nrow(data), "rows,", ncol(data), "columns\n")
+    export_region_lists(split(data$Country, data$Region))
     return(data)
   } else {
     cat("⚠ Source data not found. Creating demonstration dataset.\n")
@@ -248,6 +271,8 @@ create_gvc_demo_data <- function() {
   for (col in indicator_names) {
     data[[col]] <- pmax(10, pmin(100, data[[col]]))
   }
+
+  export_region_lists(regions)
   
   cat(sprintf("✓ GVC demonstration dataset: %d countries, %d indicators\n", 
               nrow(data), length(indicator_names)))
@@ -998,7 +1023,7 @@ cat("Coverage: Includes", nrow(complete_data), "countries across five regions\n\
 
 cat("EDITORIAL STANDARDS COMPLIANCE - FINAL CHECK:\n")
 cat("================================================================================\n")
-cat("✅ Paths: All exports in /Volumes/VALEN/Africa:LAC/Harmonization/Ready\n")
+cat("✅ Paths: All exports in /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH\n")
 cat("✅ Colors: Official GVC color scheme implemented\n")
 cat("✅ Fonts: Compatible system fonts used (Arial fallback resolved)\n")
 cat("✅ Labels: Exact pillar and indicator names per editorial standards\n")
@@ -1009,7 +1034,7 @@ cat("✅ Normalization: All indicators on 0-1 scale\n")
 cat("✅ Quality: Font errors resolved, all exports successful\n")
 
 cat("\n🎯 MISSION ACCOMPLISHED - ALL EXPORTS READY FOR PUBLICATION\n")
-cat("📁 Location: /Volumes/VALEN/Africa:LAC/Harmonization/Ready\n")
+cat("📁 Location: /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH\n")
 cat("⏰ Completed: 2025-06-07 00:18:18 UTC\n")
 cat("👤 User: Canomoncada\n")
 cat("🚀 Status: Production Ready - Editorial Standards Compliant\n")
@@ -1080,10 +1105,10 @@ cat("===========================================================================
 config <- list(
   timestamp = "2025-06-07 01:20:23",
   user = "Canomoncada",
-  base_directory = "/Volumes/VALEN/Africa:LAC/Harmonization/GVC AFRICA",
-  secondary_directory = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready",
+  base_directory = export_root,
+  secondary_directory = export_root,
   source_data_path = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex/Core_Pillars_Annex_138_Final.csv",
-  country_list_path = "/Volumes/VALEN/Africa:LAC/Harmonization/GVC AFRICA/Country_Lists_Complete_Pipeline.csv",
+  country_list_path = file.path(export_root, "Country_Lists_Complete_Pipeline.csv"),
   session_id = paste0("GVC_PERFECT_", format(Sys.time(), "%Y%m%d_%H%M%S"))
 )
 
@@ -1984,10 +2009,10 @@ cat("===========================================================================
 config <- list(
   timestamp = "2025-06-07 01:38:37",
   user = "Canomoncada",
-  base_directory = "/Volumes/VALEN/Africa:LAC/Harmonization/GVC AFRICA",
-  secondary_directory = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready",
+  base_directory = export_root,
+  secondary_directory = export_root,
   source_data_path = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex/Core_Pillars_Annex_138_Final.csv",
-  country_list_path = "/Volumes/VALEN/Africa:LAC/Harmonization/GVC AFRICA/Country_Lists_Complete_Pipeline.csv",
+  country_list_path = file.path(export_root, "Country_Lists_Complete_Pipeline.csv"),
   session_id = paste0("GVC_COMPLETE_", format(Sys.time(), "%Y%m%d_%H%M%S"))
 )
 
@@ -4500,7 +4525,7 @@ log_message("COMPREHENSIVE STATISTICAL SUMMARIES AND ANALYSIS SECTION COMPLETED 
 # Current Date and Time (UTC - YYYY-MM-DD HH:MM:SS formatted): 2025-06-07 01:36:17
 # Current User's Login: Canomoncada
 # Status: COMPLETE UNIFIED VERSION - ALL PARTS 1-11 INTEGRATED
-# Export Directory: /Volumes/VALEN/Africa:LAC/Harmonization/Ready
+# Export Directory: /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH
 # Framework Components: Complete Master Perfect - Production Ready
 # =====================================================================================
 
@@ -4510,7 +4535,7 @@ cat("===========================================================================
 cat("Framework Date: 2025-06-07 01:36:17 UTC\n")
 cat("Lead Developer: Canomoncada\n")
 cat("Version: Complete Master Perfect - All Components Integrated\n")
-cat("Export Directory: /Volumes/VALEN/Africa:LAC/Harmonization/Ready\n")
+cat("Export Directory: /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH\n")
 cat("Status: Production ready with all 13 outputs + advanced components\n")
 cat("================================================================================\n\n")
 
@@ -4571,10 +4596,10 @@ package_status <- load_complete_packages(required_packages)
 config <- list(
   timestamp = "2025-06-07 01:36:17",
   user = "Canomoncada",
-  base_directory = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready",
-  figures_path = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready/figures",
-  ranking_tables_path = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready/ranking_tables",
-  country_list_path = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready/Country_Lists_Complete_Pipeline.csv",
+  base_directory = export_root,
+  figures_path = file.path(export_root, "figures"),
+  ranking_tables_path = file.path(export_root, "ranking_tables"),
+  country_list_path = file.path(export_root, "Country_Lists_Complete_Pipeline.csv"),
   source_data_path = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex/Core_Pillars_Annex_138_Final.csv",
   session_id = paste0("GVC_PERFECT_", format(Sys.time(), "%Y%m%d_%H%M%S"))
 )
@@ -5006,8 +5031,10 @@ message("PART 5: Creating All 9 Comprehensive Figures")
 create_gvc_caption <- function(special_note = NULL, num_countries = NULL) {
   coverage_text <- if (!is.null(num_countries)) {
     paste0("Coverage: Includes ", num_countries, " countries across five regions (see Country Lists).")
-  } else {
+  } else if (exists("complete_data")) {
     paste0("Coverage: Includes ", nrow(complete_data), " countries across five regions (see Country Lists).")
+  } else {
+    "Coverage: Includes countries across five regions (see Country Lists)."
   }
   
   base_caption <- paste0(
@@ -5991,7 +6018,7 @@ create_technical_methodology_documentation <- function() {
     "Canomoncada (2025). Complete Master GVC Readiness Analysis Framework.\n",
     "Version: Complete Master Perfect - All Components Integrated.\n",
     "Created: 2025-06-07 01:44:37 UTC.\n",
-    "Export Directory: /Volumes/VALEN/Africa:LAC/Harmonization/Ready\n\n",
+    "Export Directory: /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH\n\n",
     
     "Data Sources:\n",
     "- ITU: Internet and Mobile Connectivity Indicators\n",
@@ -6066,7 +6093,7 @@ create_user_guide_documentation <- function() {
     
     "FILE ORGANIZATION:\n",
     "================================================================================\n",
-    "Main Directory: ", ifelse(exists("config"), config$base_directory, "/Volumes/VALEN/Africa:LAC/Harmonization/Ready"), "\n\n",
+    "Main Directory: ", ifelse(exists("config"), config$base_directory, "/Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH"), "\n\n",
     
     "Key Folders:\n",
     "├── figures/                    # GVC Editorial Standard figures\n",
@@ -6814,7 +6841,7 @@ cat("===========================================================================
 # Current Date and Time (UTC - YYYY-MM-DD HH:MM:SS formatted): 2025-06-07 01:07:13
 # Current User's Login: Canomoncada
 # Status: COMPLETE MASTER VERSION - PEER REVIEW AND REPLICATION READY
-# Export Directory: /Volumes/VALEN/Africa:LAC/Harmonization/Ready
+# Export Directory: /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH
 # Framework Components: Parts 1-11 Complete with Advanced Analytics
 # =====================================================================================
 
@@ -6824,7 +6851,7 @@ cat("===========================================================================
 cat("Framework Date: 2025-06-07 01:07:13 UTC\n")
 cat("Lead Developer: Canomoncada\n")
 cat("Version: Complete Master Perfect - All Components Implemented\n")
-cat("Export Directory: /Volumes/VALEN/Africa:LAC/Harmonization/Ready\n")
+cat("Export Directory: /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH\n")
 cat("Status: Production ready with all 13 outputs + advanced components\n")
 cat("================================================================================\n\n")
 
@@ -6885,10 +6912,10 @@ package_status <- load_complete_packages(required_packages)
 config <- list(
   timestamp = "2025-06-07 01:07:13",
   user = "Canomoncada",
-  base_directory = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready",
-  figures_path = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready/figures",
-  ranking_tables_path = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready/ranking_tables",
-  country_list_path = "/Volumes/VALEN/Africa:LAC/Harmonization/Ready/Country_Lists_Complete_Pipeline.csv",
+  base_directory = export_root,
+  figures_path = file.path(export_root, "figures"),
+  ranking_tables_path = file.path(export_root, "ranking_tables"),
+  country_list_path = file.path(export_root, "Country_Lists_Complete_Pipeline.csv"),
   source_data_path = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex/Core_Pillars_Annex_138_Final.csv",
   session_id = paste0("GVC_PERFECT_", format(Sys.time(), "%Y%m%d_%H%M%S"))
 )

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Analyze and visualize readiness metrics for African economies in global value ch
 ```
 GVC_AFRICA/
 ├── Data/                  # Raw input data files (NOT included in repo)
-├── exports/
-│   ├── figures/           # Output: Plots/figures (not tracked)
-│   └── clean/             # Output: Cleaned/processed data (not tracked)
+├── outputs/               # Generated analysis results
+│   ├── figures/           # Plots/figures (not tracked)
+│   └── clean/             # Cleaned/processed data (not tracked)
 ├── logs/                  # Optional logs (not tracked)
 ├── scripts/               # Optional modular scripts
 ├── africa_china_gvc_master_replication.R
@@ -83,17 +83,29 @@ The script will sequentially execute all workflow parts (0–10):
 - **Part 9:** Validation and diagnostics
 - **Part 10:** Final outputs and documentation
 
+### Output Directory
+
+All figures, tables, and cleaned data are written to a single export root
+directory. By default this path is:
+
+```
+/Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH
+```
+
+You can modify the `export_root` variable at the top of each script if you wish
+to save the outputs elsewhere.
+
 ---
 
 ### 3. Expected Outputs
 
 After successful replication:
 
-- **Cleaned Data:**  
-  Saved in `exports/clean/` (e.g., `Business_Ready_clean.csv`, `master_dataset.csv`)
+- **Cleaned Data:**
+  Saved in `outputs/clean/` (e.g., `Business_Ready_clean.csv`, `master_dataset.csv`)
 
-- **Figures/Plots:**  
-  Saved in `exports/figures/` (e.g., `pca_analysis.png`, `africa_readiness_map.png`)
+- **Figures/Plots:**
+  Saved in `outputs/figures/` (e.g., `pca_analysis.png`, `africa_readiness_map.png`)
 
 - **Analysis Results:**  
   Summary statistics, cluster assignments, and policy recommendations

--- a/Visual_Pack
+++ b/Visual_Pack
@@ -23,6 +23,9 @@ options(
   encoding = "UTF-8"
 )
 
+# Unified export directory used across all modules
+export_root <- "/Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH"
+
 # Professional package management with comprehensive error handling
 required_packages_master <- c(
   # Core data manipulation
@@ -93,9 +96,9 @@ MASTER_GVC_CONFIG <- list(
     source_base = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex",
     source_final_export = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex/FInal Export",
     core_data_file = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex/Core_Pillars_Annex_138_Final.csv",
-    
+
     # Master export destination - UPDATED TO REQUESTED PATH
-    master_export = "/Volumes/VALEN/Africa:LAC/Harmonization/Cafrica",
+    master_export = export_root,
     
     # Subdirectories for organized output
     subdirs = list(
@@ -4265,7 +4268,7 @@ cat("\nPipeline execution completed. All outputs ready for institutional use.\n"
 # Current Date and Time (UTC - YYYY-MM-DD HH:MM:SS formatted): 2025-06-04 20:01:52
 # Current User's Login: Canomoncada
 # Status: COMPLETE MASTER VERSION - ALL COMPONENTS INTEGRATED
-# Export Directory: /Volumes/VALEN/Africa:LAC/Harmonization/Cafrica/Insert
+# Export Directory: /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH
 # =====================================================================================
 
 cat("================================================================================\n")
@@ -4274,7 +4277,7 @@ cat("===========================================================================
 cat("Framework Date: 2025-06-04 20:01:52 UTC\n")
 cat("Lead Developer: Canomoncada\n")
 cat("Version: Complete Master - All Components Integrated\n")
-cat("Export Directory: /Volumes/VALEN/Africa:LAC/Harmonization/Cafrica/Insert\n")
+cat("Export Directory: /Volumes/VALEN/Africa:LAC/Insert/READY TO PUBLISH\n")
 cat("Status: Production ready with all features\n")
 cat("================================================================================\n\n")
 
@@ -4334,7 +4337,7 @@ package_status <- load_complete_packages(required_packages)
 config <- list(
   timestamp = "2025-06-04 20:01:52",
   user = "Canomoncada",
-  base_directory = "/Volumes/VALEN/Africa:LAC/Harmonization/Cafrica/Insert",
+  base_directory = export_root,
   source_data_path = "/Volumes/VALEN/Africa:LAC/Africa_GVC/Data Annex/Core_Pillars_Annex_138_Final.csv",
   session_id = paste0("GVC_COMPLETE_ALL_", format(Sys.time(), "%Y%m%d_%H%M%S"))
 )


### PR DESCRIPTION
## Summary
- create directory for per-region figures and a folder for region lists
- export region country lists whenever data is loaded or demo data is generated
- update directory creation function accordingly

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844bb1ea9fc8323957180a69ef6f4ce